### PR TITLE
Updates for mono/2019-06

### DIFF
--- a/reference/System.Core.xml
+++ b/reference/System.Core.xml
@@ -18790,27 +18790,6 @@
               <attribute name="System.Runtime.CompilerServices.ExtensionAttribute" />
             </attributes>
             <methods>
-              <method name="ConfigureAwait(System.Collections.Generic.IAsyncEnumerable`1[T], System.Boolean)" attrib="150" static="true" returntype="System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1[T]">
-                <attributes>
-                  <attribute name="System.Runtime.CompilerServices.ExtensionAttribute" />
-                </attributes>
-                <parameters>
-                  <parameter name="source" position="0" attrib="0" type="System.Collections.Generic.IAsyncEnumerable`1[T]" direction="this" />
-                  <parameter name="continueOnCapturedContext" position="1" attrib="0" type="System.Boolean" />
-                </parameters>
-                <generic-parameters>
-                  <generic-parameter name="T" attributes="0" />
-                </generic-parameters>
-              </method>
-              <method name="ConfigureAwait(System.IAsyncDisposable, System.Boolean)" attrib="150" static="true" returntype="System.Runtime.CompilerServices.ConfiguredAsyncDisposable">
-                <attributes>
-                  <attribute name="System.Runtime.CompilerServices.ExtensionAttribute" />
-                </attributes>
-                <parameters>
-                  <parameter name="source" position="0" attrib="0" type="System.IAsyncDisposable" direction="this" />
-                  <parameter name="continueOnCapturedContext" position="1" attrib="0" type="System.Boolean" />
-                </parameters>
-              </method>
               <method name="Unwrap(System.Threading.Tasks.Task`1[System.Threading.Tasks.Task])" attrib="150" static="true" returntype="System.Threading.Tasks.Task">
                 <attributes>
                   <attribute name="System.Runtime.CompilerServices.ExtensionAttribute" />
@@ -18828,18 +18807,6 @@
                 </parameters>
                 <generic-parameters>
                   <generic-parameter name="TResult" attributes="0" />
-                </generic-parameters>
-              </method>
-              <method name="WithCancellation(System.Collections.Generic.IAsyncEnumerable`1[T], System.Threading.CancellationToken)" attrib="150" static="true" returntype="System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1[T]">
-                <attributes>
-                  <attribute name="System.Runtime.CompilerServices.ExtensionAttribute" />
-                </attributes>
-                <parameters>
-                  <parameter name="source" position="0" attrib="0" type="System.Collections.Generic.IAsyncEnumerable`1[T]" direction="this" />
-                  <parameter name="cancellationToken" position="1" attrib="0" type="System.Threading.CancellationToken" />
-                </parameters>
-                <generic-parameters>
-                  <generic-parameter name="T" attributes="0" />
                 </generic-parameters>
               </method>
             </methods>


### PR DESCRIPTION
3 extension methods extracted from
`System.Threading.Tasks.TaskExtensions` to a new
`System.Threading.Tasks.TaskAsyncEnumerableExtensions` class.

They stay in the same namespace and being extension methods, they
should not break anything. They are located in `mscorlib.dll`, so they
should be always available.

	public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T> (this System.Collections.Generic.IAsyncEnumerable<T>, bool);
	public static System.Runtime.CompilerServices.ConfiguredAsyncDisposable ConfigureAwait (this System.IAsyncDisposable, bool);
	public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T> (this System.Collections.Generic.IAsyncEnumerable<T>, System.Threading.CancellationToken);

Context:
https://github.com/dotnet/standard/commit/ebeec50871621ac116b1257c791fc162a0ac5ea0#diff-93ef3714cd10edf17d6d8045cf3406b8,
https://github.com/xamarin/xamarin-android/pull/3155#issuecomment-502672705