### PR TITLE
More updates for mono/2019-06

### DIFF
--- a/reference/System.xml
+++ b/reference/System.xml
@@ -23794,33 +23794,6 @@
           </class>
         </classes>
       </namespace>
-      <namespace name="System.IO.Enumeration">
-        <classes>
-          <class name="FileSystemName" type="class" base="System.Object" sealed="true" abstract="true" charset="Ansi" layout="Auto">
-            <methods>
-              <method name="MatchesSimpleExpression(System.ReadOnlySpan`1[System.Char], System.ReadOnlySpan`1[System.Char], System.Boolean)" attrib="150" static="true" returntype="System.Boolean">
-                <parameters>
-                  <parameter name="expression" position="0" attrib="0" type="System.ReadOnlySpan`1[System.Char]" />
-                  <parameter name="name" position="1" attrib="0" type="System.ReadOnlySpan`1[System.Char]" />
-                  <parameter name="ignoreCase" position="2" attrib="4112" type="System.Boolean" optional="true" defaultValue="True" />
-                </parameters>
-              </method>
-              <method name="MatchesWin32Expression(System.ReadOnlySpan`1[System.Char], System.ReadOnlySpan`1[System.Char], System.Boolean)" attrib="150" static="true" returntype="System.Boolean">
-                <parameters>
-                  <parameter name="expression" position="0" attrib="0" type="System.ReadOnlySpan`1[System.Char]" />
-                  <parameter name="name" position="1" attrib="0" type="System.ReadOnlySpan`1[System.Char]" />
-                  <parameter name="ignoreCase" position="2" attrib="4112" type="System.Boolean" optional="true" defaultValue="True" />
-                </parameters>
-              </method>
-              <method name="TranslateWin32Expression(System.String)" attrib="150" static="true" returntype="System.String">
-                <parameters>
-                  <parameter name="expression" position="0" attrib="0" type="System.String" />
-                </parameters>
-              </method>
-            </methods>
-          </class>
-        </classes>
-      </namespace>
       <namespace name="System.Net">
         <classes>
           <class name="AuthenticationManager" type="class" base="System.Object" charset="Ansi" layout="Auto">
@@ -42456,21 +42429,6 @@
               </method>
               <method name="Reset()" attrib="486" virtual="true" returntype="System.Void">
                 <parameters />
-              </method>
-            </methods>
-          </class>
-          <class name="CryptographicOperations" type="class" base="System.Object" sealed="true" abstract="true" charset="Ansi" layout="Auto">
-            <methods>
-              <method name="FixedTimeEquals(System.ReadOnlySpan`1[System.Byte], System.ReadOnlySpan`1[System.Byte])" attrib="150" static="true" returntype="System.Boolean">
-                <parameters>
-                  <parameter name="left" position="0" attrib="0" type="System.ReadOnlySpan`1[System.Byte]" />
-                  <parameter name="right" position="1" attrib="0" type="System.ReadOnlySpan`1[System.Byte]" />
-                </parameters>
-              </method>
-              <method name="ZeroMemory(System.Span`1[System.Byte])" attrib="150" static="true" returntype="System.Void">
-                <parameters>
-                  <parameter name="buffer" position="0" attrib="0" type="System.Span`1[System.Byte]" />
-                </parameters>
               </method>
             </methods>
           </class>


### PR DESCRIPTION
`System.IO.Enumeration.FileSystemName` and
`System.Security.Cryptography.CryptographicOperations` classes were
removed from `System.dll` as they were duplicates of `mscorlib` ones. They
were removed as part of NS2.1 work in mono.

They were added by mistake and removed later. Because they were
already present in 16.1 and 16.2 respectively, mono team added type
forwarders to `System.dll` to avoid/lessen API breakage.

System.dll now contains:

	.class extern forwarder System.IO.Enumeration.FileSystemName
	{
	  .assembly extern mscorlib
	}
	.class extern forwarder System.Security.Cryptography.CryptographicOperations
	{
	  .assembly extern mscorlib
	}

Context:
https://github.com/mono/mono/commit/ba719acaa24e08e90b19df495a6c5a5cbe469803
https://github.com/xamarin/xamarin-android/pull/3155#issuecomment-510142890